### PR TITLE
Added input validation and working tutorial step to show expanding nodes

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,6 @@
       <h1>Wikipedia Map</h1>
       <p>A tool for visualizing the connections between Wikipedia pages by Luke Taylor</p>
       <button id="tourinit" class="shepbtn">Take the tour</button>
-      <div id="tourexpandnode"></div>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -147,6 +147,7 @@
       <h1>Wikipedia Map</h1>
       <p>A tool for visualizing the connections between Wikipedia pages by Luke Taylor</p>
       <button id="tourinit" class="shepbtn">Take the tour</button>
+      <div id="tourexpandnode"></div>
     </div>
   </div>
 
@@ -170,12 +171,12 @@
   <script type="text/javascript" src="./js/helpers.js"> </script>
   <!-- Load main functions -->
   <script type="text/javascript" src="./js/main_functions.js"> </script>
+    <!-- Build help popup -->
+  <script type="text/javascript" src="./js/help.js"> </script>
   <!-- Load the main script -->
   <script type="text/javascript" src="./js/main.js"> </script>
   <!-- Load serialization functions -->
   <script type="text/javascript" src="./js/network_serialize.js"> </script>
-  <!-- Build help popup -->
-  <script type="text/javascript" src="./js/help.js"> </script>
   <!-- Load bindings -->
   <script type="text/javascript" src="./js/bindings.js"> </script>
   <!-- Transform comma field -->

--- a/js/help.js
+++ b/js/help.js
@@ -148,18 +148,18 @@ function expandNodeNext() {
   addItem(cf, "Cat"); //add example item
   resetNetworkFromInput(); 
   //get position of starting node
-  // var startNode = cf.getElementsByClassName("item")[0];
-  // var position = startNode.getBoundingClientRect();  
-  // var startDiv = document.getElementById("tourexpandnode");
-  // startDiv.style.position = "absolute";
-  // startDiv.style.top = position.top;
-  // startDiv.style.left = position.left;
-
-  var position = network.getPosition(startNode.id);
+  var startNode = cf.getElementsByClassName("item")[0];
+  var position = startNode.getBoundingClientRect();  
   var startDiv = document.getElementById("tourexpandnode");
   startDiv.style.position = "absolute";
   startDiv.style.top = position.top;
   startDiv.style.left = position.left;
+
+  // var position = network.getPosition(startNode.id);
+  // var startDiv = document.getElementById("tourexpandnode");
+  // startDiv.style.position = "absolute";
+  // startDiv.style.top = position.top;
+  // startDiv.style.left = position.left;
   shepherd.next();
 }
 

--- a/js/help.js
+++ b/js/help.js
@@ -94,28 +94,6 @@ shepherd.addStep({
     {
       text: "Let's go!",
       classes: "shepbtn",
-      action: expandNodeNext
-    }
-  ],
-  tetherOptions :{
-      'attachment':'top left',
-      'targetAttachment':'bottom center',
-       'offset':'0px -35px'
-  },
-});
-
-shepherd.addStep({
-  text: ["Here's an example node. Click on it to expand it!"],
-  attachTo: "#tourexpandnode bottom", //change to the new invisible div
-  buttons: [
-    {
-      text: "Back",
-      classes: "shepherd-button-secondary",
-      action: shepherd.next
-    },
-    {
-      text: "Got it!",
-      classes: "shepbtn",
       action: shepherd.next
     }
   ],
@@ -141,27 +119,6 @@ function opaque () {
 }
 shepherd.on("complete", opaque);
 shepherd.on("cancel", opaque);
-
-// Custom action handler to show how to expand node
-function expandNodeNext() {
-  var cf = document.getElementsByClassName("commafield")[0] 
-  addItem(cf, "Cat"); //add example item
-  resetNetworkFromInput(); 
-  //get position of starting node
-  var startNode = cf.getElementsByClassName("item")[0];
-  var position = startNode.getBoundingClientRect();  
-  var startDiv = document.getElementById("tourexpandnode");
-  startDiv.style.position = "absolute";
-  startDiv.style.top = position.top;
-  startDiv.style.left = position.left;
-
-  // var position = network.getPosition(startNode.id);
-  // var startDiv = document.getElementById("tourexpandnode");
-  // startDiv.style.position = "absolute";
-  // startDiv.style.top = position.top;
-  // startDiv.style.left = position.left;
-  shepherd.next();
-}
 
 // Prompt user for input when none detected
 function noInputDetected() {

--- a/js/help.js
+++ b/js/help.js
@@ -94,6 +94,28 @@ shepherd.addStep({
     {
       text: "Let's go!",
       classes: "shepbtn",
+      action: expandNodeNext
+    }
+  ],
+  tetherOptions :{
+      'attachment':'top left',
+      'targetAttachment':'bottom center',
+       'offset':'0px -35px'
+  },
+});
+
+shepherd.addStep({
+  text: ["Here's an example node. Click on it to expand it!"],
+  attachTo: "#tourexpandnode bottom", //change to the new invisible div
+  buttons: [
+    {
+      text: "Back",
+      classes: "shepherd-button-secondary",
+      action: shepherd.next
+    },
+    {
+      text: "Got it!",
+      classes: "shepbtn",
       action: shepherd.next
     }
   ],
@@ -120,7 +142,34 @@ function opaque () {
 shepherd.on("complete", opaque);
 shepherd.on("cancel", opaque);
 
+// Custom action handler to show how to expand node
+function expandNodeNext() {
+  var cf = document.getElementsByClassName("commafield")[0] 
+  addItem(cf, "Cat"); //add example item
+  resetNetworkFromInput(); 
+  //get position of starting node
+  // var startNode = cf.getElementsByClassName("item")[0];
+  // var position = startNode.getBoundingClientRect();  
+  // var startDiv = document.getElementById("tourexpandnode");
+  // startDiv.style.position = "absolute";
+  // startDiv.style.top = position.top;
+  // startDiv.style.left = position.left;
 
+  var position = network.getPosition(startNode.id);
+  var startDiv = document.getElementById("tourexpandnode");
+  startDiv.style.position = "absolute";
+  startDiv.style.top = position.top;
+  startDiv.style.left = position.left;
+  shepherd.next();
+}
+
+// Prompt user for input when none detected
+function noInputDetected() {
+  shepherd.start();
+  shepherd.next();
+  shepherd.next(); //skip to the step explaining how input works
+  formbox.style.opacity = 1;
+}
 
 // Load the modal with the README and other info
 
@@ -197,7 +246,8 @@ for (var i=0;i<backButtons.length;i++) {
   backButtons[i].onclick=animateReturn;
 }
 
-
+// Is the user on a touch device?
+var isTouchDevice = 'd' in document.documentElement;
 
 var controlspage = document.getElementById("controls");
 

--- a/js/main.js
+++ b/js/main.js
@@ -2,7 +2,7 @@
 // a function for resetting it to a brand new page.
 
 
-var nodes, edges, network, startID; //Global variables
+var nodes, edges, network; //Global variables
 var startpages = [];
 // Tracks whether the network needs to be reset. Used to prevent deleting nodes
 // when multiple nodes need to be created, because AJAX requests are async.

--- a/js/main.js
+++ b/js/main.js
@@ -42,7 +42,7 @@ function makeNetwork() {
 //Reset the network to be new each time.
 function resetNetwork(start) {
   if (!initialized) makeNetwork();
-  startID = getNeutralId(start);
+  var startID = getNeutralId(start);
   startpages = [startID]; // Register the page as an origin node
   tracenodes = [];
   traceedges = [];

--- a/js/main.js
+++ b/js/main.js
@@ -2,14 +2,11 @@
 // a function for resetting it to a brand new page.
 
 
-var nodes, edges, network; //Global variables
+var nodes, edges, network, startID; //Global variables
 var startpages = [];
 // Tracks whether the network needs to be reset. Used to prevent deleting nodes
 // when multiple nodes need to be created, because AJAX requests are async.
 var needsreset = true;
-
-// Is the user on a touch device?
-var isTouchDevice = 'ontouchstart' in document.documentElement;
 
 var container = document.getElementById('container');
 //Global options
@@ -45,7 +42,7 @@ function makeNetwork() {
 //Reset the network to be new each time.
 function resetNetwork(start) {
   if (!initialized) makeNetwork();
-  var startID = getNeutralId(start);
+  startID = getNeutralId(start);
   startpages = [startID]; // Register the page as an origin node
   tracenodes = [];
   traceedges = [];
@@ -92,10 +89,10 @@ function resetNetworkFromInput() {
   var cf = document.getElementsByClassName("commafield")[0];
   // Items entered.
   var inputs = getItems(cf);
-  // If no input is given, add an item for the page about Wikipedia as a fallback
+  // If no input is given, prompt user to enter articles 
   if (!inputs[0]) {
-    addItem(cf, "Wikipedia");
-    inputs = getItems(cf);
+    noInputDetected();
+    return;
   }
 
   for (var i=0; i<inputs.length; i++) {


### PR DESCRIPTION
To make sure users can't just click 'Go' without entering any articles, I've created the function noInputDetected() in the help.js class. It starts a Shepherd tour and goes to the third step (shows how the input works). Figured this was the cleanest solution. It was undefined at first (the functions called in main.js), so in index.html I had to put the <script> call to help.js before main.js. Also moved the isTouchDevice declaration to the help.js file so it won't be undefined after this change. Let me know if that's an issue?

Like you suggested, I've used a floating invisible div over a start node (the shepherd step can't attach to a text node cause there's no ID or class property). Tried the standard way of finding an element's position - getBoundingClientRect() - but the text box isn't fully aligning on top of the node. Also when I resize the window, I guess the div moves, and so does the text box - not really ideal. 

The best way I can think of is to use network.getPosition(startNode) so that would return the x and y within the canvas. Adding this to the x and y of the canvas should give us the position of the startNode. For reference: http://visjs.org/docs/network/

BUT because of the switched external script calls, network (defined in main.js) is now undefined in help.js.... so I can't do that. I could just switch them back? And just not use the shepherd tour for input validation I guess. Thoughts?
