### PR TITLE
Remove back button on first Shepherd step

### DIFF
--- a/js/help.js
+++ b/js/help.js
@@ -24,11 +24,6 @@ shepherd.addStep({
   attachTo: '#input bottom',
   buttons: [
     {
-      text: 'Back',
-      classes: 'shepherd-button-secondary',
-      action: shepherd.back,
-    },
-    {
       text: 'Next',
       classes: 'shepbtn',
       action: shepherd.next,


### PR DESCRIPTION
Basic fix to https://github.com/controversial/wikipedia-map/issues/45.

The "X" button is still available for closing the tour and works just fine.

(PR with correct branch, replacing https://github.com/controversial/wikipedia-map/pull/46)